### PR TITLE
fix: use themed HadithCard for visible text in collection details

### DIFF
--- a/lib/pages/collection_details_page.dart
+++ b/lib/pages/collection_details_page.dart
@@ -4,7 +4,7 @@ import 'package:buck/database_helper.dart';
 import 'package:buck/models/hadith.dart';
 import 'package:buck/models/collection.dart';
 import 'package:buck/components/custom_appbar.dart';
-import 'package:buck/pages/hadith_page.dart'; // Reuse HadithCard from here or separate component
+import 'package:buck/components/hadith_card.dart';
 
 class CollectionDetailsPage extends StatefulWidget {
   final Collection collection;
@@ -46,12 +46,8 @@ class _CollectionDetailsPageState extends State<CollectionDetailsPage> {
                   itemCount: _hadiths.length,
                   itemBuilder: (context, index) {
                     final hadith = _hadiths[index];
-                    // Reuse HadithCard from HadithPage
-                    // Note: We need to import the HighlightBuilder or just pass a simple one
                     return HadithCard(
                       hadith: hadith,
-                      highlightQuery: "",
-                      highlightBuilder: (text, query, context) => TextSpan(text: text),
                     );
                   },
                 ),


### PR DESCRIPTION
## Summary
- Switch `collection_details_page.dart` import from `hadith_page.dart` to `components/hadith_card.dart`
- The standalone `HadithCard` component uses `ThemeProvider` for proper text styling
- Removes the raw `TextSpan` `highlightBuilder` that had no color/theme awareness

## Root cause
`collection_details_page.dart` imported `HadithCard` from `hadith_page.dart` which uses a `highlightBuilder` callback that creates a plain `TextSpan(text: text)` with no color — inheriting the background color and making text invisible.

Closes #30

## Test plan
- [ ] Open a collection with hadiths — text is visible in both light and dark themes
- [ ] Verify text appearance matches the hadith list page

🤖 Generated with [Claude Code](https://claude.com/claude-code)